### PR TITLE
set the hardcoded interpolation constant to 0 which disables interpolation

### DIFF
--- a/src/maxon_epos_ethercat_sdk/Maxon.cpp
+++ b/src/maxon_epos_ethercat_sdk/Maxon.cpp
@@ -102,7 +102,7 @@ bool Maxon::startup() {
 
   // Set Interpolation
   success &= sdoVerifyWrite(OD_INDEX_INTERPOLATION_TIME_PERIOD, 0x01, false,
-                            static_cast<uint8_t>(2),
+                            static_cast<uint8_t>(0),
                             configuration_.configRunSdoVerifyTimeout);
 
   success &= sdoVerifyWrite(OD_INDEX_INTERPOLATION_TIME_PERIOD, 0x02, false,


### PR DESCRIPTION
The interpolation constant is currently hard coded to the value: 0.002. This results in errors if you don't run your ethercat-master update loop at approximately the same frequency.
By setting the constant to zero, interpolation is disabled and therefore gets rid of this error.